### PR TITLE
Set static url to serve from jalapeño.net domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 additional_info: >-
   September 14 & 15, 2024
 # baseurl: "jalapeño" # the subpath of your site, e.g. /blog
-# url: "https://jconfmexico.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: https://jalapeño.net
 twitter_username: JalapenoUnconf
 github_username:  JConfMexico
 social_username: jconfmexico


### PR DESCRIPTION
Long story short, Github Pages `site.github.url` resolves to the HTTP website instead of the HTTPS.
If we set the `site.url` statically then it will resolve with the HTTPS [from the template we are using](https://github.com/broccolini/swiss/blob/cbf02071aff32c59030a55b0dadbe450eefa4aa3/_includes/head.html#L9).
We would need to change that if we are serving via HTTP or form a different domain.

Created a [PR to fix it from the template](https://github.com/broccolini/swiss/pull/165), but it's common practice to set the full URL to the Jekyll config.